### PR TITLE
Tauri port number fix

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "build": {
     "beforeDevCommand": "pnpm dev",
     "beforeBuildCommand": "pnpm build",
-    "devPath": "http://localhost:1420",
+    "devPath": "http://localhost:4000",
     "distDir": "../dist",
     "withGlobalTauri": false
   },


### PR DESCRIPTION
Tauri references the incorrect frontend dev port number at `http://localhost:1420`.

This PR changes it to match vues default port number at `http://localhost:4000`.